### PR TITLE
Handle the absence of stack

### DIFF
--- a/ts/baseQueueHandler.ts
+++ b/ts/baseQueueHandler.ts
@@ -111,7 +111,7 @@ abstract class BaseQueueHandler {
     msg.properties.headers.errors = {
       name: err.name,
       message: err.message,
-      stack: err.stack.substr(0, 200),
+      stack: err.stack && err.stack.substr(0, 200),
       time: new Date().toString()
     };
   }


### PR DESCRIPTION
If an object is thrown that is not Error (does not include the `stack`), the message remains unacked and cannot move on to dlq