### PR TITLE
Teach rabbit-queue RPCs to  handle a stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.40.tgz",
-      "integrity": "sha1-rKevngAQ5D817CCzdk1E49gbxN8=",
+      "version": "12.6.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
       "dev": true
     },
     "@types/node-uuid": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/amqplib": "0.3.29",
     "@types/mocha": "2.2.32",
-    "@types/node": "6.0.40",
+    "@types/node": "12.6.8",
     "@types/node-uuid": "0.0.28",
     "@types/should": "8.1.30",
     "@types/sinon": "1.16.30",

--- a/ts/replyQueue.ts
+++ b/ts/replyQueue.ts
@@ -77,7 +77,6 @@ function handleStreamReply(msg: amqp.Message, id: string) {
       return;
     }
     delete replyHandlers[id];
-    console.log('deleted');
     streamHandler = streamHandlers[id] = new Readable({ objectMode: true, read() {} });
     replyHandler(null, streamHandler);
   }

--- a/ts/test/baseQueueHandlerTest.ts
+++ b/ts/test/baseQueueHandlerTest.ts
@@ -125,7 +125,6 @@ describe('Test baseQueueHandler', function() {
     try {
       await rabbit.getReply(this.name, { test: 'data' }, { correlationId: '4' });
     } catch (e) {
-      console.log(e);
       e.should.eql({ foo: 'banana' });
     }
   });

--- a/ts/test/replyQueueTest.ts
+++ b/ts/test/replyQueueTest.ts
@@ -4,7 +4,9 @@ import * as sinon from 'sinon';
 import * as ReplyQueue from '../replyQueue';
 import Rabbit from '../rabbit';
 import Queue from '../queue';
+import { Readable } from 'stream';
 const sandbox = sinon.sandbox.create();
+import * as should from 'should';
 
 describe('Test ReplyQueue', function() {
   let rabbit: Rabbit;
@@ -68,5 +70,60 @@ describe('Test ReplyQueue', function() {
     };
     ReplyQueue.addHandler(1, handler);
     stub.callArgWith(1, { properties: { correlationId: 1 }, content: 'null' });
+  });
+
+  it('should call Handler on message with isStream: true', async function() {
+    rabbit = new Rabbit(this.url);
+    await rabbit.connected;
+    const stub = sandbox.stub(rabbit.channel, 'consume');
+    await ReplyQueue.createReplyQueue(rabbit.channel);
+    let handler;
+    let promise = new Promise((resolve, reject) => {
+      handler = async (err, body) => {
+        try {
+          body.should.be.instanceOf(Readable);
+          const chunks = [];
+          for await (const chunk of body) {
+            chunks.push(chunk.toString());
+          }
+          chunks.should.eql(['AB', 'BC']);
+        } catch (e) {
+          reject(e);
+        }
+        resolve();
+      };
+    });
+    ReplyQueue.addHandler(1, handler);
+    stub.callArgWith(1, {
+      properties: { correlationId: 1, headers: { isStream: true } },
+      content: Buffer.from(JSON.stringify('AB'))
+    });
+    stub.callArgWith(1, {
+      properties: { correlationId: 1, headers: { isStream: true } },
+      content: Buffer.from(JSON.stringify('BC'))
+    });
+    stub.callArgWith(1, {
+      properties: { correlationId: 1, headers: { isStream: true } },
+      content: Buffer.from(JSON.stringify(null))
+    });
+    await promise;
+  });
+
+  it('should call throw error if called getReply with isStream:true with same correlationId', async function() {
+    rabbit = new Rabbit(this.url);
+    await rabbit.connected;
+    const stub = sandbox.stub(rabbit.channel, 'consume');
+    await ReplyQueue.createReplyQueue(rabbit.channel);
+    let handler = () => {};
+    ReplyQueue.addHandler(2, handler);
+    stub.callArgWith(1, {
+      properties: { correlationId: 2, headers: { isStream: true } },
+      content: Buffer.from(JSON.stringify('AB'))
+    });
+    should.throws(() => ReplyQueue.addHandler(2, handler), /Already exists stream handler with this id: 2/);
+    stub.callArgWith(1, {
+      properties: { correlationId: 2, headers: { isStream: true } },
+      content: Buffer.from(JSON.stringify(null))
+    });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "suppressImplicitAnyIndexErrors": true,
     "outDir": "./js",
     "sourceMap": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "lib": ["es6", "esnext.asynciterable"]
   },
   "filesGlob": ["./*.ts"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -27,7 +27,7 @@
     "no-debugger": true,
     // "no-duplicate-key": true,
     "no-duplicate-variable": true,
-    "no-empty": true,
+    "no-empty": false,
     "no-eval": true,
     "no-string-literal": true,
     "no-switch-case-fall-through": true,


### PR DESCRIPTION
```javascript
    const stream = new Readable({ read() {} });
    await queue.subscribe((msg, ack) => ack(null, stream));
    stream.push('AB');
    stream.push('BC');
    stream.push(null);


   const result = await Queue.getReply(content, headers, rabbit.channel, this.name, queue);
    for await (const chunk of result) {
      // do sth with chunk
    }
```