### PR TITLE
Add the ability to stop streams on demand of requester

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,22 @@ log4js.configure({
 
 ### Changelog
 
+### v4.2.x to > v4.3.x
+
+RPC stream enhancement: Ability to stop communication on demand when requested data received is sufficient
+
+eg:
+
+```js
+const reply = await rabbit.getReply('demoQueue', { test: 'data' }, { headers: { test: 1, backpressure: true }, correlationId: '1' });
+for await (const chunk of reply) {
+    console.log(`Received chunk: ${chunk.toString()}`);
+    if ("sufficient_data_received") {
+        reply.emit(Queue.STOP_STREAM);
+    }
+}
+```
+
 ### v4.x.x to > v4.2.x
 
 Get reply as a stream supports two more optional headers inside properties:

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ log4js.configure({
 
 Attention: The following functionality works with nodejs v10.14.2 and higher. In previous node versions there was a problem not resolving async iteration on destroyed streams
 
-RPC stream enhancement: Ability to stop communication on demand when requested data received is sufficient
+RPC stream enhancement: When backpressure is enabled, the consumer can stop communication, when data received is sufficient
 
 eg:
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ log4js.configure({
 
 ### v4.2.x to > v4.3.x
 
+Attention: The following functionality works with nodejs v10.14.2 and higher. In previous node versions there was a problem not resolving async iteration on destroyed streams
+
 RPC stream enhancement: Ability to stop communication on demand when requested data received is sufficient
 
 eg:

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -439,6 +439,8 @@ describe('Test Queue class', function() {
     const result = await Queue.getReply(content, headers, rabbit.channel, this.name, queue);
     result.emit(Queue.STOP_STREAM);
     stream.push('BC');
+    stream.push('CD');
+    stream.push('DE');
     stream.push(null);
     result.constructor.should.equal(Readable);
     const chunks = [];

--- a/test/replyQueue.test.ts
+++ b/test/replyQueue.test.ts
@@ -56,7 +56,7 @@ describe('Test ReplyQueue', function() {
     ReplyQueue.addHandler(1, handler);
     stub.callArgWith(1, {
       properties: { correlationId: 1 },
-      content: new Buffer(JSON.stringify(Queue.ERROR_DURING_REPLY))
+      content: Buffer.from(JSON.stringify(Queue.ERROR_DURING_REPLY))
     });
   });
 

--- a/ts/reply-queue.ts
+++ b/ts/reply-queue.ts
@@ -119,7 +119,6 @@ function handleStreamReply(msg: amqp.Message, id: string) {
 
   if (stopped[id]) {
     options.channel.sendToQueue(msg.properties.replyTo, Buffer.from(JSON.stringify(Queue.STOP_STREAM_MESSAGE)), properties);
-    streamHandler.emit('end');
     streamHandler.destroy();
     delete options[id];
     delete stopped[id];

--- a/ts/reply-queue.ts
+++ b/ts/reply-queue.ts
@@ -120,7 +120,7 @@ function handleStreamReply(msg: amqp.Message, id: string) {
   if (stopped[id]) {
     options.channel.sendToQueue(msg.properties.replyTo, new Buffer(JSON.stringify(Queue.STOP_STREAM_MESSAGE)), properties);
     streamHandler.destroy();
-    options[id] = { replyTo: msg.properties.replyTo, properties };
+    delete options[id];
     delete stopped[id];
     delete streamHandlers[id];
     return;

--- a/ts/reply-queue.ts
+++ b/ts/reply-queue.ts
@@ -118,7 +118,8 @@ function handleStreamReply(msg: amqp.Message, id: string) {
   backpressure = !streamHandler.push(obj);
 
   if (stopped[id]) {
-    options.channel.sendToQueue(msg.properties.replyTo, new Buffer(JSON.stringify(Queue.STOP_STREAM_MESSAGE)), properties);
+    options.channel.sendToQueue(msg.properties.replyTo, Buffer.from(JSON.stringify(Queue.STOP_STREAM_MESSAGE)), properties);
+    streamHandler.emit('end');
     streamHandler.destroy();
     delete options[id];
     delete stopped[id];


### PR DESCRIPTION
When using rpc streams the requester of data has the ability to stop communication when data received is sufficient. 
This can be accomplished by emiting an event to the underlying readable stream:

```
const reply = await rabbit.getReply('demoQueue', { test: 'data' }, { correlationId: '5' });
for await (const chunk of reply) {
    console.log(`Received chunk: ${chunk.toString()}`);
    if ("sufficient_data_received") {
        reply.emit(Queue.STOP_STREAM);
    }
}
```