### PR TITLE
PoC for adding a default channel and for every queue a separate channel

### DIFF
--- a/ts/base-queue-handler.ts
+++ b/ts/base-queue-handler.ts
@@ -6,6 +6,7 @@ import { decode } from './encode-decode';
 abstract class BaseQueueHandler {
   public dlqName: string;
   public retries: number;
+  public prefetch: number;
   public retryDelay: number;
   public logger;
   public logEnabled: boolean;
@@ -22,6 +23,7 @@ abstract class BaseQueueHandler {
     {
       retries = 3,
       retryDelay = 1000,
+      prefetch = rabbit.prefetch,
       logEnabled = true,
       scope = <'SINGLETON' | 'PROTOTYPE'>BaseQueueHandler.SCOPES.singleton,
       createAndSubscribeToQueue = true
@@ -31,6 +33,7 @@ abstract class BaseQueueHandler {
 
     this.retries = retries;
     this.retryDelay = retryDelay;
+    this.prefetch = prefetch;
     this.logger = logger;
     this.logEnabled = logEnabled;
     this.scope = scope;
@@ -71,6 +74,7 @@ abstract class BaseQueueHandler {
           const instance = new (<any>this.constructor)(this.queueName, this.rabbit, {
             retries: this.retries,
             retryDelay: this.retryDelay,
+            prefetch: this.prefetch,
             logger: this.logger,
             logEnabled: this.logEnabled,
             scope: this.scope,


### PR DESCRIPTION
This is a rough idea acting as a discussion starter for https://github.com/Workable/rabbit-queue/issues/23 

The idea is:
- One default channel used to establish the connection
- Every queue gets its own channel in order to support different prefetches. This is what multi-threaded clients do (e.g. java).
- When consuming each queue will use a different channel, when publishing the default channel will be used (we could use the queue's channel for publishing as well).
- A single connection remains