### PR TITLE
Use two rabbitmq connections

### DIFF
--- a/test/delay-queue.test.ts
+++ b/test/delay-queue.test.ts
@@ -29,12 +29,12 @@ describe('Test DelayQueue', function() {
   });
 
   it('should createDelayQueue', async function() {
-    await DelayQueue.createDelayQueueReply(rabbit.channel, 'delay');
+    await DelayQueue.createDelayQueueReply(rabbit.consumeChannel, 'delay');
     const queueInstance = sinon.createStubInstance(Queue.default);
     const stub = sandbox.stub(Queue, 'default').returns(queueInstance);
-    await DelayQueue.createDelayQueue(rabbit.channel, 'delay');
+    await DelayQueue.createDelayQueue(rabbit.consumeChannel, 'delay');
     stub.args[0].should.eql([
-      rabbit.channel,
+      rabbit.consumeChannel,
       'delay',
       {
         deadLetterExchange: '',
@@ -46,29 +46,29 @@ describe('Test DelayQueue', function() {
   it('should createDelayQueueReply', async function() {
     const queueInstance = sinon.createStubInstance(Queue.default);
     const stub = sandbox.stub(Queue, 'default').returns(queueInstance);
-    await DelayQueue.createDelayQueueReply(rabbit.channel, 'delay');
-    stub.args.should.eql([[rabbit.channel, 'delay_reply', {}]]);
+    await DelayQueue.createDelayQueueReply(rabbit.consumeChannel, 'delay');
+    stub.args.should.eql([[rabbit.consumeChannel, 'delay_reply', {}]]);
   });
 
   it('should publishWithDelay and create not existing queue', async function() {
-    await DelayQueue.createDelayQueueReply(rabbit.channel, 'delay');
+    await DelayQueue.createDelayQueueReply(rabbit.consumeChannel, 'delay');
     const stub = sandbox.stub(Queue.default, 'publish').returns(null);
-    await DelayQueue.publishWithDelay('delay', {}, {}, rabbit.channel, 'test');
+    await DelayQueue.publishWithDelay('delay', {}, {}, rabbit.consumeChannel, 'test');
     stub.calledOnce.should.be.true();
     stub.args[0].should.containDeep([{ queueName: 'test', obj: {} }, { expiration: '10000' }, 'delay_10000']);
   });
 
   it('should publishWithGivenDelay', async function() {
-    await DelayQueue.createDelayQueueReply(rabbit.channel, 'delay');
+    await DelayQueue.createDelayQueueReply(rabbit.consumeChannel, 'delay');
     const stub = sandbox.stub(Queue.default, 'publish').returns(null);
-    await DelayQueue.publishWithDelay('delay', {}, { expiration: '3000' }, rabbit.channel, 'test');
+    await DelayQueue.publishWithDelay('delay', {}, { expiration: '3000' }, rabbit.consumeChannel, 'test');
     stub.calledOnce.should.be.true();
     stub.args[0].should.containDeep([{ queueName: 'test', obj: {} }, { expiration: '3000' }, 'delay_3000']);
   });
 
   it('should call on Message', async function() {
-    await DelayQueue.createDelayQueueReply(rabbit.channel, 'delay');
-    const queue = new Queue.default(rabbit.channel, 'queue', { exclusive: true });
+    await DelayQueue.createDelayQueueReply(rabbit.consumeChannel, 'delay');
+    const queue = new Queue.default(rabbit.consumeChannel, 'queue', { exclusive: true });
     const content = { content: true };
     let resolve;
     const promise = new Promise((r, reject) => {
@@ -80,7 +80,7 @@ describe('Test DelayQueue', function() {
     });
 
     const spy = sandbox.spy(Queue.default, 'publish');
-    await DelayQueue.publishWithDelay('delay', content, { expiration: '10' }, rabbit.channel, 'queue');
+    await DelayQueue.publishWithDelay('delay', content, { expiration: '10' }, rabbit.consumeChannel, 'queue');
     spy.calledOnce.should.be.true();
     spy.args[0].should.containDeep([{ queueName: 'queue', obj: content }, { expiration: '10' }, 'delay_10']);
     (<any>await promise).content.toString().should.eql(JSON.stringify(content));

--- a/test/exchange.test.ts
+++ b/test/exchange.test.ts
@@ -26,7 +26,7 @@ describe('Test Exchange', function() {
   });
 
   it('should publish to exchange', async function() {
-    const stub = sandbox.stub(rabbit.channel, 'publish');
+    const stub = sandbox.stub(rabbit.consumeChannel, 'publish');
     stub.callsArgWith(4, null, 'ok');
     const content = { content: true };
     const headers = {
@@ -35,45 +35,45 @@ describe('Test Exchange', function() {
       persistent: false,
       contentType: 'application/json'
     };
-    await Exchange.publish(rabbit.channel, 'exchange', 'routingKey', content, headers);
+    await Exchange.publish(rabbit.consumeChannel, 'exchange', 'routingKey', content, headers);
     stub.calledOnce.should.be.true();
     stub.args[0].slice(0, 4).should.eql(['exchange', 'routingKey', new Buffer(JSON.stringify(content)), headers]);
   });
 
   it('should publish to topic with getReply', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'publish');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'publish');
     const content = { content: true };
     const headers = {
       headers: { test: 1 },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.subscribe((msg, ack) => ack(null, 'result'));
     await rabbit.bindToTopic(this.name, 'binding');
-    const result = await Exchange.getReply(rabbit.channel, 'amq.topic', 'binding', content, headers);
+    const result = await Exchange.getReply(rabbit.consumeChannel, 'amq.topic', 'binding', content, headers);
     result.should.equal('result');
     spy.calledTwice.should.be.true();
     spy.args[0].slice(0, 4).should.eql(['amq.topic', 'binding', new Buffer(JSON.stringify(content)), headers]);
   });
 
   it('should publish to topic with getReply and timeout and fail', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'publish');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'publish');
     const content = { content: true };
     const headers = {
       headers: { test: 1 },
       correlationId: '2',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.subscribe((msg, ack) => setTimeout(() => ack(null, 'result'), 10));
     await rabbit.bindToTopic(this.name, 'binding');
     try {
-      await Exchange.getReply(rabbit.channel, 'amq.topic', 'binding', content, headers, 1);
+      await Exchange.getReply(rabbit.consumeChannel, 'amq.topic', 'binding', content, headers, 1);
       assert(false);
     } catch (error) {
       error.should.eql(new Error('Timed out'));
@@ -84,20 +84,20 @@ describe('Test Exchange', function() {
   });
 
   it('should publish to topic with getReply and fail', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'publish');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'publish');
     const content = { content: true };
     const headers = {
       headers: { test: 1 },
       correlationId: '3',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.subscribe((msg, ack) => setTimeout(() => ack('error'), 10));
     await rabbit.bindToTopic(this.name, 'binding');
     try {
-      await Exchange.getReply(rabbit.channel, 'amq.topic', 'binding', content, headers);
+      await Exchange.getReply(rabbit.consumeChannel, 'amq.topic', 'binding', content, headers);
       assert(false);
     } catch (error) {
       error.should.eql(new Error('error'));

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -16,11 +16,11 @@ describe('Test Queue class', function() {
   });
 
   beforeEach(function() {
-    this.spyAssert = sandbox.spy(rabbit.channel, 'assertQueue');
-    this.spyConsume = sandbox.spy(rabbit.channel, 'consume');
-    this.spyCancel = sandbox.spy(rabbit.channel, 'cancel');
-    this.spyDeleteQueue = sandbox.spy(rabbit.channel, 'deleteQueue');
-    this.spyPurgeQueue = sandbox.spy(rabbit.channel, 'purgeQueue');
+    this.spyAssert = sandbox.spy(rabbit.consumeChannel, 'assertQueue');
+    this.spyConsume = sandbox.spy(rabbit.consumeChannel, 'consume');
+    this.spyCancel = sandbox.spy(rabbit.consumeChannel, 'cancel');
+    this.spyDeleteQueue = sandbox.spy(rabbit.consumeChannel, 'deleteQueue');
+    this.spyPurgeQueue = sandbox.spy(rabbit.consumeChannel, 'purgeQueue');
   });
 
   afterEach(async function() {
@@ -33,7 +33,7 @@ describe('Test Queue class', function() {
   });
 
   it('should create Queue', async function() {
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.created;
     this.spyAssert.calledOnce.should.be.true();
     this.spyAssert
@@ -51,7 +51,7 @@ describe('Test Queue class', function() {
   });
 
   it('should create queue and add handler to it', async function() {
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true, noAck: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true, noAck: true });
     await queue.created;
     const handler = msg => console.log(msg);
     await queue.subscribe(handler);
@@ -63,7 +63,7 @@ describe('Test Queue class', function() {
   });
 
   it('should create queue and add handler and unsubscribe', async function() {
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true, noAck: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true, noAck: true });
     await queue.created;
     const handler = msg => console.log(msg);
     await queue.subscribe(handler);
@@ -72,15 +72,15 @@ describe('Test Queue class', function() {
   });
 
   it('should destroy queue', async function() {
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.created;
-    await Queue.destroy(rabbit.channel, this.name);
+    await Queue.destroy(rabbit.consumeChannel, this.name);
     this.spyDeleteQueue.calledOnce.should.be.true();
     this.spyDeleteQueue.calledWith(this.name).should.be.true();
   });
 
   it('should purge queue', async function() {
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.created;
     await queue.purge();
     this.spyPurgeQueue.calledOnce.should.be.true();
@@ -88,28 +88,28 @@ describe('Test Queue class', function() {
   });
 
   it('should publish to queue', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = { headers: { test: 1 }, correlationId: '1', persistent: false };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true, priority: 10 });
-    await Queue.publish(content, headers, rabbit.channel, this.name, queue);
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true, priority: 10 });
+    await Queue.publish(content, headers, rabbit.consumeChannel, this.name, queue);
     spy.calledOnce.should.be.true();
     spy.args[0].slice(0, 3).should.eql([this.name, Buffer.from(JSON.stringify(content)), headers]);
   });
 
   it('should publish to queue with getReply', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
       headers: { test: 1 },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.subscribe((msg, ack) => ack(null, 'result'));
-    const result = await Queue.getReply(content, headers, rabbit.channel, this.name, queue);
+    const result = await Queue.getReply(content, headers, rabbit.consumeChannel, this.name, queue);
     result.should.equal('result');
     spy.calledTwice.should.be.true();
     spy.args[0].slice(0, 3).should.eql([this.name, Buffer.from(JSON.stringify(content)), headers]);
@@ -122,12 +122,12 @@ describe('Test Queue class', function() {
       headers: { test: 1 },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.subscribe((msg, ack) => ack(null, Queue.STOP_PROPAGATION));
-    setTimeout(() => rabbit.publish(rabbit.channel.replyName, 'new_result', headers, ''), 10);
+    setTimeout(() => rabbit.publish(rabbit.consumeChannel.replyName, 'new_result', headers, ''), 10);
     const result = await Queue.getReply(content, headers, rabbit.publishChannel, this.name, queue);
     result.should.equal('new_result');
     spy.calledTwice.should.be.true();
@@ -135,37 +135,37 @@ describe('Test Queue class', function() {
   });
 
   it('should publish to queue with getReply and timeout', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
       headers: { test: 1 },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.subscribe((msg, ack) => setTimeout(() => ack(null, 'result'), 1));
-    const result = await Queue.getReply(content, headers, rabbit.channel, this.name, queue, 10);
+    const result = await Queue.getReply(content, headers, rabbit.consumeChannel, this.name, queue, 10);
     result.should.equal('result');
     spy.calledTwice.should.be.true();
     spy.args[0].slice(0, 3).should.eql([this.name, Buffer.from(JSON.stringify(content)), headers]);
   });
 
   it('should publish to queue with getReply and reply with error', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
       headers: { test: 1 },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.subscribe((msg, ack) => setTimeout(() => ack('error'), 1));
     try {
-      await Queue.getReply(content, headers, rabbit.channel, this.name, queue, 10);
+      await Queue.getReply(content, headers, rabbit.consumeChannel, this.name, queue, 10);
       assert(false);
     } catch (error) {
       error.should.eql(new Error('error'));
@@ -175,19 +175,19 @@ describe('Test Queue class', function() {
   });
 
   it('should publish to queue with getReply and timeout and fail', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
       headers: { test: 1 },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.subscribe((msg, ack) => setTimeout(() => ack(null, 'result'), 10));
     try {
-      await Queue.getReply(content, headers, rabbit.channel, this.name, queue, 1);
+      await Queue.getReply(content, headers, rabbit.consumeChannel, this.name, queue, 1);
       assert(false);
     } catch (error) {
       error.should.eql(new Error('Timed out'));
@@ -199,20 +199,20 @@ describe('Test Queue class', function() {
 
   it('should getReply as a stream', async function() {
     if (process.env.SKIP_STREAM) return;
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
       headers: { test: 1, backpressure: true },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     const stream = new Readable({ objectMode: true, read() {} });
     await queue.subscribe((msg, ack) => ack(null, stream));
     stream.push('AB');
-    const result = await Queue.getReply(content, headers, rabbit.channel, this.name, queue);
+    const result = await Queue.getReply(content, headers, rabbit.consumeChannel, this.name, queue);
     stream.push('BC');
     stream.push(null);
     result.constructor.should.equal(Readable);
@@ -235,21 +235,21 @@ describe('Test Queue class', function() {
     spy.args.should.eql([
       [this.name, Buffer.from(JSON.stringify(content)), headers, spy.args[0][3]],
       [
-        rabbit.channel.replyName,
+        rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify('AB')),
         { ...streamHeaders, correlationId: '1.0' },
         spy.args[1][3]
       ],
-      [rabbit.channel.replyName, Buffer.from(JSON.stringify(null)), { ...replyHeaders, correlationId: '1.0' }],
+      [rabbit.consumeChannel.replyName, Buffer.from(JSON.stringify(null)), { ...replyHeaders, correlationId: '1.0' }],
       [
-        rabbit.channel.replyName,
+        rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify('BC')),
         { ...streamHeaders, correlationId: '1.1' },
         spy.args[3][3]
       ],
-      [rabbit.channel.replyName, Buffer.from(JSON.stringify(null)), { ...replyHeaders, correlationId: '1.1' }],
+      [rabbit.consumeChannel.replyName, Buffer.from(JSON.stringify(null)), { ...replyHeaders, correlationId: '1.1' }],
       [
-        rabbit.channel.replyName,
+        rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify(null)),
         { correlationId: '1.1', contentType: 'application/json', headers: { isStream: true, correlationId: '1' } },
         spy.args[5][3]
@@ -262,15 +262,15 @@ describe('Test Queue class', function() {
   it('should getReply as a stream and use backpressure', async function() {
     if (process.env.SKIP_STREAM) return;
     const content = { content: true };
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const headers = {
       headers: { test: 1, backpressure: true },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     const stream = new Readable({ objectMode: true, read() {} });
     await queue.subscribe((msg, ack) => ack(null, stream));
     stream.push({ a: 1 });
@@ -278,7 +278,7 @@ describe('Test Queue class', function() {
       stream.push({ a: i });
     }
     stream.push(null);
-    const result = await Queue.getReply(content, headers, rabbit.channel, this.name, queue);
+    const result = await Queue.getReply(content, headers, rabbit.consumeChannel, this.name, queue);
     result.constructor.should.equal(Readable);
     await new Promise(r => setTimeout(r, 100));
     const chunks = [];
@@ -289,37 +289,37 @@ describe('Test Queue class', function() {
 
     const args1_15 = [];
     for (let i = 1; i < 16; i++) {
-      args1_15.push([rabbit.channel.replyName, { a: i }], [rabbit.channel.replyName, null]);
+      args1_15.push([rabbit.consumeChannel.replyName, { a: i }], [rabbit.consumeChannel.replyName, null]);
     }
     spy.args
       .map(args => [args[0], JSON.parse(args[1].toString())])
       .should.eql([
         [this.name, content],
         ...args1_15,
-        [rabbit.channel.replyName, { a: 16 }],
-        [rabbit.channel.replyName, { backpressure: true }],
-        [rabbit.channel.replyName, { a: 17 }],
-        [rabbit.channel.replyName, null],
-        [rabbit.channel.replyName, null]
+        [rabbit.consumeChannel.replyName, { a: 16 }],
+        [rabbit.consumeChannel.replyName, { backpressure: true }],
+        [rabbit.consumeChannel.replyName, { a: 17 }],
+        [rabbit.consumeChannel.replyName, null],
+        [rabbit.consumeChannel.replyName, null]
       ]);
   });
 
   it('should getReply as a stream of Objects and handle error', async function() {
     if (process.env.SKIP_STREAM) return;
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
       headers: { test: 1 },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     const stream = new Readable({ objectMode: true, read() {} });
     await queue.subscribe((msg, ack) => ack(null, stream));
     stream.push('AB');
-    const result = await Queue.getReply(content, headers, rabbit.channel, this.name, queue);
+    const result = await Queue.getReply(content, headers, rabbit.consumeChannel, this.name, queue);
     stream.push('BC');
     stream.emit('error', new Error('test-error'));
     result.constructor.should.equal(Readable);
@@ -340,9 +340,9 @@ describe('Test Queue class', function() {
 
     spy.args.should.eql([
       [this.name, Buffer.from(JSON.stringify(content)), headers, spy.args[0][3]],
-      [rabbit.channel.replyName, Buffer.from(JSON.stringify('AB')), { ...streamHeaders, correlationId: '1.0' }],
+      [rabbit.consumeChannel.replyName, Buffer.from(JSON.stringify('AB')), { ...streamHeaders, correlationId: '1.0' }],
       [
-        rabbit.channel.replyName,
+        rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify({ error: true, error_code: 999, error_message: 'test-error' })),
         { ...streamHeaders, correlationId: '1.0' },
         spy.args[2][3]
@@ -352,20 +352,20 @@ describe('Test Queue class', function() {
 
   it('should getReply as a stream of Buffers and handle error', async function() {
     if (process.env.SKIP_STREAM) return;
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const properties = {
       headers: { test: 1, backpressure: true },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     const stream = new Readable({ read() {} });
     await queue.subscribe((msg, ack) => ack(null, stream));
     stream.push('AB');
-    const result = await Queue.getReply(content, properties, rabbit.channel, this.name, queue);
+    const result = await Queue.getReply(content, properties, rabbit.consumeChannel, this.name, queue);
     stream.push('BC');
     stream.emit('error', new Error('test-error'));
     result.constructor.should.equal(Readable);
@@ -392,14 +392,14 @@ describe('Test Queue class', function() {
     spy.args.should.eql([
       [this.name, Buffer.from(JSON.stringify(content)), properties, spy.args[0][3]],
       [
-        rabbit.channel.replyName,
+        rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify('AB')),
         { ...streamHeaders, correlationId: '1.0' },
         spy.args[1][3]
       ],
-      [rabbit.channel.replyName, Buffer.from(JSON.stringify(null)), { ...replyHeaders, correlationId: '1.0' }],
+      [rabbit.consumeChannel.replyName, Buffer.from(JSON.stringify(null)), { ...replyHeaders, correlationId: '1.0' }],
       [
-        rabbit.channel.replyName,
+        rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify({ error: true, error_code: 999, error_message: 'test-error' })),
         { correlationId: '1.0', contentType: 'application/json', headers: { isStream: true, correlationId: '1' } },
         spy.args[3][3]
@@ -408,35 +408,35 @@ describe('Test Queue class', function() {
   });
 
   it('should bind to exchange', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'bindQueue');
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
-    await Queue.bindToExchange('amq.topic', this.name, rabbit.channel, this.name, queue);
+    const spy = sandbox.spy(rabbit.consumeChannel, 'bindQueue');
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
+    await Queue.bindToExchange('amq.topic', this.name, rabbit.consumeChannel, this.name, queue);
     spy.calledWith(this.name, 'amq.topic', this.name);
   });
 
   it('should unbind to exchange', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'unbindQueue');
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
-    await Queue.unbindFromExchange('amq.topic', this.name, rabbit.channel, this.name, queue);
+    const spy = sandbox.spy(rabbit.consumeChannel, 'unbindQueue');
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
+    await Queue.unbindFromExchange('amq.topic', this.name, rabbit.consumeChannel, this.name, queue);
     spy.calledWith(this.name, 'amq.topic', this.name);
   });
 
   it('should getReply as a stream and stop on demand', async function() {
     if (process.env.SKIP_STREAM) return;
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
       headers: { test: 1, backpressure: true },
       correlationId: '1',
       persistent: false,
-      replyTo: rabbit.channel.replyName,
+      replyTo: rabbit.consumeChannel.replyName,
       contentType: 'application/json'
     };
-    const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     const stream = new Readable({ objectMode: true, read() {} });
     await queue.subscribe((msg, ack) => ack(null, stream));
     stream.push('AB');
-    const result = await Queue.getReply(content, headers, rabbit.channel, this.name, queue);
+    const result = await Queue.getReply(content, headers, rabbit.consumeChannel, this.name, queue);
     result.emit(Queue.STOP_STREAM);
     stream.push('BC');
     stream.push('CD');
@@ -462,20 +462,20 @@ describe('Test Queue class', function() {
     spy.args.should.eql([
       [this.name, Buffer.from(JSON.stringify(content)), headers, spy.args[0][3]],
       [
-        rabbit.channel.replyName,
+        rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify('AB')),
         { ...streamHeaders, correlationId: '1.0' },
         spy.args[1][3]
       ],
-      [rabbit.channel.replyName, Buffer.from(JSON.stringify(null)), { ...replyHeaders, correlationId: '1.0' }],
+      [rabbit.consumeChannel.replyName, Buffer.from(JSON.stringify(null)), { ...replyHeaders, correlationId: '1.0' }],
       [
-        rabbit.channel.replyName,
+        rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify('BC')),
         { ...streamHeaders, correlationId: '1.1' },
         spy.args[3][3]
       ],
       [
-        rabbit.channel.replyName,
+        rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify(Queue.STOP_STREAM_MESSAGE)),
         { ...replyHeaders, correlationId: '1.1' },
       ]

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -116,7 +116,7 @@ describe('Test Queue class', function() {
   });
 
   it('should publish to queue with getReply but get reply after queue acknowledment', async function() {
-    const spy = sandbox.spy(rabbit.channel, 'sendToQueue');
+    const spy = sandbox.spy(rabbit.publishChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
       headers: { test: 1 },
@@ -128,7 +128,7 @@ describe('Test Queue class', function() {
     const queue = new Queue(rabbit.channel, this.name, { exclusive: true });
     await queue.subscribe((msg, ack) => ack(null, Queue.STOP_PROPAGATION));
     setTimeout(() => rabbit.publish(rabbit.channel.replyName, 'new_result', headers, ''), 10);
-    const result = await Queue.getReply(content, headers, rabbit.channel, this.name, queue);
+    const result = await Queue.getReply(content, headers, rabbit.publishChannel, this.name, queue);
     result.should.equal('new_result');
     spy.calledTwice.should.be.true();
     spy.args[0].slice(0, 3).should.eql([this.name, Buffer.from(JSON.stringify(content)), headers]);

--- a/test/rabbit.test.ts
+++ b/test/rabbit.test.ts
@@ -57,17 +57,20 @@ describe('Test rabbit class', function() {
     rabbit = new Rabbit(this.url, { socketOptions: 'socketOptions' });
     (<any>rabbit).connect();
     await rabbit.connected;
-    connectStub.args.should.eql([[this.url, 'socketOptions']]);
+    connectStub.args.should.eql([
+      [this.url, 'socketOptions'],
+      [this.url, 'socketOptions']
+    ]);
   });
 
   it('should call connect only once', async function() {
-    const spy = sandbox.spy(Rabbit.prototype, 'createChannel');
-    const stub = sandbox.stub(ReplyQueue, 'createReplyQueue');
+    const createChannelSpy = sandbox.spy(Rabbit.prototype, 'createChannel');
+    const createReplyQueueStub = sandbox.stub(ReplyQueue, 'createReplyQueue');
     rabbit = new Rabbit(this.url);
     (<any>rabbit).connect();
     await rabbit.connected;
-    spy.calledOnce.should.be.true();
-    stub.called.should.be.true();
+    createChannelSpy.args.should.eql([[rabbit.connection], [rabbit.publishConnection]]);
+    createReplyQueueStub.called.should.be.true();
   });
 
   it('should not call createReplyQueue', async function() {
@@ -123,13 +126,12 @@ describe('Test rabbit class', function() {
   });
 
   it('should publish to queue by adding prefix_', async function() {
-    const stub = sandbox.stub(Queue, 'publish');
+    const publishStub = sandbox.stub(Queue, 'publish');
     rabbit = new Rabbit(this.url, { prefix: 'test' });
     const content = { content: true };
     const headers = { headers: { test: 1 } };
     await rabbit.publish(`test_${this.name}`, content, headers);
-    stub.calledOnce.should.be.true();
-    stub.calledWith(content, headers, rabbit.channel, `test_${this.name}`, undefined).should.be.true();
+    publishStub.args.should.eql([[content, headers, rabbit.publishChannel, `test_${this.name}`, undefined]]);
   });
 
   it('should publish to queue by adding only prefix when name starts with .', async function() {
@@ -139,7 +141,7 @@ describe('Test rabbit class', function() {
     const headers = { headers: { test: 1 } };
     await rabbit.publish(this.name3, content, headers);
     stub.calledOnce.should.be.true();
-    stub.calledWith(content, headers, rabbit.channel, `test${this.name3}`, undefined).should.be.true();
+    stub.calledWith(content, headers, rabbit.publishChannel, `test${this.name3}`, undefined).should.be.true();
   });
 
   it('should publish to queue with Delay', async function() {
@@ -161,7 +163,7 @@ describe('Test rabbit class', function() {
     const reply = await rabbit.getReply(`test_${this.name}`, content, headers);
     reply.should.equal('reply');
     stub.calledOnce.should.be.true();
-    stub.calledWith(content, headers, rabbit.channel, `test_${this.name}`, undefined).should.be.true();
+    stub.calledWith(content, headers, rabbit.publishChannel, `test_${this.name}`, undefined).should.be.true();
   });
 
   it('should publish to topic with getReply', async function() {
@@ -173,7 +175,7 @@ describe('Test rabbit class', function() {
     const reply = await rabbit.getTopicReply(`test_${this.name}`, content, headers);
     reply.should.equal('reply');
     stub.calledOnce.should.be.true();
-    stub.calledWith(rabbit.channel, 'amq.topic', `test_${this.name}`, content, headers, undefined).should.be.true();
+    stub.calledWith(rabbit.publishChannel, 'amq.topic', `test_${this.name}`, content, headers, undefined).should.be.true();
   });
 
   it('should publish to exchange', async function() {
@@ -183,7 +185,7 @@ describe('Test rabbit class', function() {
     const headers = { headers: { test: 1 } };
     await rabbit.publishExchange('amq.topic', 'testKey', content, headers);
     stub.calledOnce.should.be.true();
-    stub.calledWith(rabbit.channel, 'amq.topic', 'testKey', content, headers).should.be.true();
+    stub.calledWith(rabbit.publishChannel, 'amq.topic', 'testKey', content, headers).should.be.true();
   });
 
   it('should publish to topic', async function() {
@@ -193,7 +195,7 @@ describe('Test rabbit class', function() {
     const headers = { headers: { test: 1 } };
     await rabbit.publishTopic('testKey', content, headers);
     stub.calledOnce.should.be.true();
-    stub.calledWith(rabbit.channel, 'amq.topic', 'testKey', content, headers).should.be.true();
+    stub.calledWith(rabbit.publishChannel, 'amq.topic', 'testKey', content, headers).should.be.true();
   });
 
   it('should bind to exchange', async function() {

--- a/test/rabbit.test.ts
+++ b/test/rabbit.test.ts
@@ -69,7 +69,7 @@ describe('Test rabbit class', function() {
     rabbit = new Rabbit(this.url);
     (<any>rabbit).connect();
     await rabbit.connected;
-    createChannelSpy.args.should.eql([[rabbit.connection], [rabbit.publishConnection]]);
+    createChannelSpy.args.should.eql([[rabbit.consumeConnection], [rabbit.publishConnection]]);
     createReplyQueueStub.called.should.be.true();
   });
 
@@ -105,7 +105,7 @@ describe('Test rabbit class', function() {
     const stub = sandbox.stub(Queue.prototype, 'subscribe');
     rabbit = new Rabbit(this.url);
     await rabbit.connected;
-    const spy = sandbox.spy(rabbit.channel, 'prefetch');
+    const spy = sandbox.spy(rabbit.consumeChannel, 'prefetch');
     const handler = () => ({});
     let promises = [];
     promises.push(rabbit.createQueue(this.name, { exclusive: true, prefetch: 20 }, handler));
@@ -151,7 +151,7 @@ describe('Test rabbit class', function() {
     const headers = { headers: { test: 1 } };
     await rabbit.publishWithDelay(`test_${this.name}`, content, headers);
     stub.calledOnce.should.be.true();
-    stub.args.should.eql([['test_delay', content, headers, rabbit.channel, `test_${this.name}`]]);
+    stub.args.should.eql([['test_delay', content, headers, rabbit.consumeChannel, `test_${this.name}`]]);
   });
 
   it('should publish to queue with getReply', async function() {
@@ -202,34 +202,34 @@ describe('Test rabbit class', function() {
     const stub = sandbox.stub(Queue, 'bindToExchange');
     rabbit = new Rabbit(this.url);
     await rabbit.bindToExchange(this.name, 'amq.topic', 'key');
-    stub.calledWith('amq.topic', 'key', rabbit.channel, this.name, undefined).should.be.true();
+    stub.calledWith('amq.topic', 'key', rabbit.consumeChannel, this.name, undefined).should.be.true();
   });
 
   it('should bind to topic', async function() {
     const stub = sandbox.stub(Queue, 'bindToExchange');
     rabbit = new Rabbit(this.url);
     await rabbit.bindToTopic(this.name, 'key');
-    stub.calledWith('amq.topic', 'key', rabbit.channel, this.name, undefined).should.be.true();
+    stub.calledWith('amq.topic', 'key', rabbit.consumeChannel, this.name, undefined).should.be.true();
   });
 
   it('should unbind from exchange', async function() {
     const stub = sandbox.stub(Queue, 'unbindFromExchange');
     rabbit = new Rabbit(this.url);
     await rabbit.unbindFromExchange(this.name, 'amq.topic', 'key');
-    stub.calledWith('amq.topic', 'key', rabbit.channel, this.name, undefined).should.be.true();
+    stub.calledWith('amq.topic', 'key', rabbit.consumeChannel, this.name, undefined).should.be.true();
   });
 
   it('should unbind from topic', async function() {
     const stub = sandbox.stub(Queue, 'unbindFromExchange');
     rabbit = new Rabbit(this.url);
     await rabbit.unbindFromTopic(this.name, 'key');
-    stub.calledWith('amq.topic', 'key', rabbit.channel, this.name, undefined).should.be.true();
+    stub.calledWith('amq.topic', 'key', rabbit.consumeChannel, this.name, undefined).should.be.true();
   });
 
   it('should destroy queue', async function() {
     const stub = sandbox.stub(Queue, 'destroy');
     rabbit = new Rabbit(this.url, { prefix: 'test' });
     await rabbit.destroyQueue(this.name);
-    stub.calledWith(rabbit.channel, `test_${this.name}`).should.be.true();
+    stub.calledWith(rabbit.consumeChannel, `test_${this.name}`).should.be.true();
   });
 });

--- a/test/replyQueue.test.ts
+++ b/test/replyQueue.test.ts
@@ -26,18 +26,18 @@ describe('Test ReplyQueue', function() {
   it('should createReplyQueue', async function() {
     rabbit = new Rabbit(this.url);
     await rabbit.connected;
-    const stub = sandbox.stub(rabbit.channel, 'consume');
-    await ReplyQueue.createReplyQueue(rabbit.channel);
+    const stub = sandbox.stub(rabbit.consumeChannel, 'consume');
+    await ReplyQueue.createReplyQueue(rabbit.consumeChannel);
     stub.calledOnce.should.be.true();
-    stub.args[0][0].should.eql(rabbit.channel.replyName);
+    stub.args[0][0].should.eql(rabbit.consumeChannel.replyName);
     stub.args[0][2].should.eql({ noAck: true });
   });
 
   it('should call Handler on message', async function() {
     rabbit = new Rabbit(this.url);
     await rabbit.connected;
-    const stub = sandbox.stub(rabbit.channel, 'consume');
-    await ReplyQueue.createReplyQueue(rabbit.channel);
+    const stub = sandbox.stub(rabbit.consumeChannel, 'consume');
+    await ReplyQueue.createReplyQueue(rabbit.consumeChannel);
     const handler = (err, body) => {
       body.should.equal('test_body');
     };
@@ -48,8 +48,8 @@ describe('Test ReplyQueue', function() {
   it('should call Handler on message and fail', async function() {
     rabbit = new Rabbit(this.url);
     await rabbit.connected;
-    const stub = sandbox.stub(rabbit.channel, 'consume');
-    await ReplyQueue.createReplyQueue(rabbit.channel);
+    const stub = sandbox.stub(rabbit.consumeChannel, 'consume');
+    await ReplyQueue.createReplyQueue(rabbit.consumeChannel);
     const handler = (err, body) => {
       err.should.eql(new Error());
     };
@@ -63,8 +63,8 @@ describe('Test ReplyQueue', function() {
   it('should call Handler on message with null message and succeed', async function() {
     rabbit = new Rabbit(this.url);
     await rabbit.connected;
-    const stub = sandbox.stub(rabbit.channel, 'consume');
-    await ReplyQueue.createReplyQueue(rabbit.channel);
+    const stub = sandbox.stub(rabbit.consumeChannel, 'consume');
+    await ReplyQueue.createReplyQueue(rabbit.consumeChannel);
     const handler = (err, body) => {
       assert(body === null);
     };
@@ -76,9 +76,9 @@ describe('Test ReplyQueue', function() {
     rabbit = new Rabbit(this.url);
     await rabbit.connected;
     if (process.env.SKIP_STREAM) return;
-    const stub = sandbox.stub(rabbit.channel, 'consume');
-    const stubSendToQueue = sandbox.stub(rabbit.channel, 'sendToQueue');
-    await ReplyQueue.createReplyQueue(rabbit.channel);
+    const stub = sandbox.stub(rabbit.consumeChannel, 'consume');
+    const stubSendToQueue = sandbox.stub(rabbit.consumeChannel, 'sendToQueue');
+    await ReplyQueue.createReplyQueue(rabbit.consumeChannel);
     let handler;
     let promise = new Promise((resolve, reject) => {
       handler = async (err, body) => {
@@ -115,9 +115,9 @@ describe('Test ReplyQueue', function() {
     rabbit = new Rabbit(this.url);
     await rabbit.connected;
     if (process.env.SKIP_STREAM) return;
-    const stub = sandbox.stub(rabbit.channel, 'consume');
-    const stubSendToQueue = sandbox.stub(rabbit.channel, 'sendToQueue');
-    await ReplyQueue.createReplyQueue(rabbit.channel);
+    const stub = sandbox.stub(rabbit.consumeChannel, 'consume');
+    const stubSendToQueue = sandbox.stub(rabbit.consumeChannel, 'sendToQueue');
+    await ReplyQueue.createReplyQueue(rabbit.consumeChannel);
     let handler;
     let promise = new Promise((resolve, reject) => {
       handler = async (err, body) => {
@@ -157,8 +157,8 @@ describe('Test ReplyQueue', function() {
     rabbit = new Rabbit(this.url);
     await rabbit.connected;
     if (process.env.SKIP_STREAM) return;
-    const stub = sandbox.stub(rabbit.channel, 'consume');
-    await ReplyQueue.createReplyQueue(rabbit.channel);
+    const stub = sandbox.stub(rabbit.consumeChannel, 'consume');
+    await ReplyQueue.createReplyQueue(rabbit.consumeChannel);
     let handler = () => {};
     ReplyQueue.addHandler(2, handler);
     stub.callArgWith(1, {
@@ -176,8 +176,8 @@ describe('Test ReplyQueue', function() {
     rabbit = new Rabbit(this.url);
     await rabbit.connected;
     if (process.env.SKIP_STREAM) return;
-    const stub = sandbox.stub(rabbit.channel, 'consume');
-    await ReplyQueue.createReplyQueue(rabbit.channel);
+    const stub = sandbox.stub(rabbit.consumeChannel, 'consume');
+    await ReplyQueue.createReplyQueue(rabbit.consumeChannel);
     let handler;
     let promise = new Promise((resolve, reject) => {
       handler = async (err, body) => {
@@ -215,8 +215,8 @@ describe('Test ReplyQueue', function() {
     rabbit = new Rabbit(this.url);
     await rabbit.connected;
     if (process.env.SKIP_STREAM) return;
-    const stub = sandbox.stub(rabbit.channel, 'consume');
-    await ReplyQueue.createReplyQueue(rabbit.channel);
+    const stub = sandbox.stub(rabbit.consumeChannel, 'consume');
+    await ReplyQueue.createReplyQueue(rabbit.consumeChannel);
     let handler;
     let promise = new Promise((resolve, reject) => {
       handler = async (err, body) => {

--- a/ts/reply-queue.ts
+++ b/ts/reply-queue.ts
@@ -34,7 +34,7 @@ export function getReply(content: any, properties: amqp.Options.Publish = {}, ch
       {
         persistent: false,
         correlationId,
-        replyTo: channel.replyName,
+        replyTo: options.channel.replyName,
         contentType: 'application/json'
       },
       properties
@@ -117,15 +117,17 @@ function handleStreamReply(msg: amqp.Message, id: string) {
   };
 
   if (stopped[id]) {
-    options.channel.sendToQueue(msg.properties.replyTo, Buffer.from(JSON.stringify(Queue.STOP_STREAM_MESSAGE)), properties);
+    options.channel.sendToQueue(
+      msg.properties.replyTo,
+      Buffer.from(JSON.stringify(Queue.STOP_STREAM_MESSAGE)),
+      properties
+    );
     streamHandler.push(null);
     delete options[id];
     delete stopped[id];
     delete streamHandlers[id];
     logger.info(
-      `[${correlationId}] <- Returning (stop event received) the end of stream reply ${
-        msg.content.byteLength
-      } bytes`
+      `[${correlationId}] <- Returning (stop event received) the end of stream reply ${msg.content.byteLength} bytes`
     );
     return;
   }


### PR DESCRIPTION
This is a preliminary pr that splits consumers with publishers as recommended by cloudamqp here: 
https://www.cloudamqp.com/blog/2018-01-19-part4-rabbitmq-13-common-errors.html to avoid consumers being throttled.
A new one will follow that will allow clients to define different prefetch lenghts per queue.