### PR TITLE
Teach rabbit-queue to pass options to streams and stop 1 step earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,18 @@ rabbit
 
 rabbit
   .getReply('queueName', { test: 'data' }, { correlationId: '1' })
-  .then(reply => console.log('received reply', reply));
+  .then((reply) => console.log('received reply', reply));
 
 rabbit
   .getReply('queueName', { test: 'data' }, { correlationId: '1' }, '', 100)
-  .then(reply => console.log('received reply', reply))
-  .catch(error => console.log('Timed out after 100ms'));
+  .then((reply) => console.log('received reply', reply))
+  .catch((error) => console.log('Timed out after 100ms'));
 
 rabbit.bindToTopic('queueName', 'routingKey');
 rabbit
   .getTopicReply('routingKey', { test: 'data' }, { correlationId: '1' }, '', 100)
-  .then(reply => console.log('received reply', reply))
-  .catch(error => console.log('Timed out after 100ms'));
+  .then((reply) => console.log('received reply', reply))
+  .catch((error) => console.log('Timed out after 100ms'));
 ```
 
 ## Binding to topics
@@ -152,7 +152,7 @@ new DemoHandler('demoQueue', rabbit, {
 
 rabbit
   .getReply('demoQueue', { test: 'data' }, { correlationId: '5' })
-  .then(reply => console.log('received reply', reply));
+  .then((reply) => console.log('received reply', reply));
 ```
 
 ### Example where handle throws an error
@@ -220,6 +220,25 @@ rabbit.on('log', (component, level, ...args) => console.log(`[${level}] ${compon
 
 ### Changelog
 
+### New in v5.4.x
+
+- Support for stream RPC to pass options for the Readable stream created in the caller.
+  e.g.
+
+```js
+const reply = await rabbit.getReply(
+  'demoQueue',
+  { test: 'data' },
+  { headers: { test: 1, backpressure: true, options: { highWaterMark: 1 } }, correlationId: '1' }
+);
+for await (const chunk of reply) {
+  console.log(`Received chunk: ${chunk.toString()}`);
+  if ('sufficient_data_received') {
+    reply.emit(Queue.STOP_STREAM);
+  }
+}
+```
+
 ### v4.x.x to v5.x.x
 
 - Support for Node LTS v6 and v8 was dropped. You should use Node v10 and higher.
@@ -255,7 +274,7 @@ See https://www.rabbitmq.com/consumer-prefetch.html for more details
 
 RPC stream enhancement: When backpressure is enabled, the consumer can stop communication, when data received is sufficient
 
-eg:
+e.g.
 
 ```js
 const reply = await rabbit.getReply(

--- a/test/queue.test.ts
+++ b/test/queue.test.ts
@@ -6,9 +6,9 @@ import Queue from '../ts/queue';
 import { Readable } from 'stream';
 const sandbox = sinon.createSandbox();
 
-describe('Test Queue class', function() {
+describe('Test Queue class', function () {
   let rabbit: Rabbit;
-  before(async function() {
+  before(async function () {
     this.url = process.env.RABBIT_URL || 'amqp://localhost';
     this.name = 'test.queue';
     rabbit = new Rabbit(this.url, {});
@@ -16,7 +16,7 @@ describe('Test Queue class', function() {
     await rabbit.connected;
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     this.spyAssert = sandbox.spy(rabbit.consumeChannel, 'assertQueue');
     this.spyConsume = sandbox.spy(rabbit.consumeChannel, 'consume');
     this.spyCancel = sandbox.spy(rabbit.consumeChannel, 'cancel');
@@ -24,16 +24,16 @@ describe('Test Queue class', function() {
     this.spyPurgeQueue = sandbox.spy(rabbit.consumeChannel, 'purgeQueue');
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await rabbit.destroyQueue(this.name);
     sandbox.restore();
   });
 
-  after(async function() {
+  after(async function () {
     await rabbit.close();
   });
 
-  it('should create Queue', async function() {
+  it('should create Queue', async function () {
     const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.created;
     this.spyAssert.calledOnce.should.be.true();
@@ -51,10 +51,10 @@ describe('Test Queue class', function() {
       .should.be.true();
   });
 
-  it('should create queue and add handler to it', async function() {
+  it('should create queue and add handler to it', async function () {
     const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true, noAck: true });
     await queue.created;
-    const handler = msg => console.log(msg);
+    const handler = (msg) => console.log(msg);
     await queue.subscribe(handler);
     this.spyConsume.calledOnce.should.be.true();
     this.spyConsume.args[0][0].should.equal(this.name);
@@ -63,16 +63,16 @@ describe('Test Queue class', function() {
     });
   });
 
-  it('should create queue and add handler and unsubscribe', async function() {
+  it('should create queue and add handler and unsubscribe', async function () {
     const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true, noAck: true });
     await queue.created;
-    const handler = msg => console.log(msg);
+    const handler = (msg) => console.log(msg);
     await queue.subscribe(handler);
     await queue.unsubscribe();
     this.spyCancel.calledOnce.should.be.true();
   });
 
-  it('should destroy queue', async function() {
+  it('should destroy queue', async function () {
     const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.created;
     await Queue.destroy(rabbit.consumeChannel, this.name);
@@ -80,7 +80,7 @@ describe('Test Queue class', function() {
     this.spyDeleteQueue.calledWith(this.name).should.be.true();
   });
 
-  it('should purge queue', async function() {
+  it('should purge queue', async function () {
     const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await queue.created;
     await queue.purge();
@@ -88,7 +88,7 @@ describe('Test Queue class', function() {
     this.spyPurgeQueue.calledWith(this.name).should.be.true();
   });
 
-  it('should publish to queue', async function() {
+  it('should publish to queue', async function () {
     const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = { headers: { test: 1 }, correlationId: '1', persistent: false };
@@ -98,7 +98,7 @@ describe('Test Queue class', function() {
     spy.args[0].slice(0, 3).should.eql([this.name, Buffer.from(JSON.stringify(content)), headers]);
   });
 
-  it('should publish to queue with getReply', async function() {
+  it('should publish to queue with getReply', async function () {
     const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
@@ -116,7 +116,7 @@ describe('Test Queue class', function() {
     spy.args[0].slice(0, 3).should.eql([this.name, Buffer.from(JSON.stringify(content)), headers]);
   });
 
-  it('should publish to queue with getReply but get reply after queue acknowledment', async function() {
+  it('should publish to queue with getReply but get reply after queue acknowledment', async function () {
     const spy = sandbox.spy(rabbit.publishChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
@@ -135,7 +135,7 @@ describe('Test Queue class', function() {
     spy.args[0].slice(0, 3).should.eql([this.name, Buffer.from(JSON.stringify(content)), headers]);
   });
 
-  it('should publish to queue with getReply and timeout', async function() {
+  it('should publish to queue with getReply and timeout', async function () {
     const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
@@ -153,7 +153,7 @@ describe('Test Queue class', function() {
     spy.args[0].slice(0, 3).should.eql([this.name, Buffer.from(JSON.stringify(content)), headers]);
   });
 
-  it('should publish to queue with getReply and reply with error', async function() {
+  it('should publish to queue with getReply and reply with error', async function () {
     const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
@@ -175,7 +175,7 @@ describe('Test Queue class', function() {
     spy.args[0].slice(0, 3).should.eql([this.name, Buffer.from(JSON.stringify(content)), headers]);
   });
 
-  it('should publish to queue with getReply and timeout and fail', async function() {
+  it('should publish to queue with getReply and timeout and fail', async function () {
     const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
@@ -195,10 +195,10 @@ describe('Test Queue class', function() {
     }
     spy.calledOnce.should.be.true();
     spy.args[0].slice(0, 3).should.eql([this.name, Buffer.from(JSON.stringify(content)), headers]);
-    await new Promise(r => setTimeout(r, 10));
+    await new Promise((r) => setTimeout(r, 10));
   });
 
-  it('should getReply as a stream', async function() {
+  it('should getReply as a stream', async function () {
     if (process.env.SKIP_STREAM) return;
     const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
@@ -225,7 +225,7 @@ describe('Test Queue class', function() {
     const streamHeaders = {
       correlationId: '1',
       contentType: 'application/json',
-      headers: { isStream: true, correlationId: '1' },
+      headers: { isStream: true, correlationId: '1', options: undefined },
       persistent: false,
       replyTo: queue.channel.replyName
     };
@@ -252,7 +252,11 @@ describe('Test Queue class', function() {
       [
         rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify(null)),
-        { correlationId: '1.1', contentType: 'application/json', headers: { isStream: true, correlationId: '1' } },
+        {
+          correlationId: '1.1',
+          contentType: 'application/json',
+          headers: { isStream: true, correlationId: '1', options: undefined }
+        },
         spy.args[5][3]
       ]
     ]);
@@ -260,7 +264,7 @@ describe('Test Queue class', function() {
     spy.args[3][3].should.be.Function();
   });
 
-  it('should getReply as a stream and use backpressure', async function() {
+  it('should getReply as a stream and use backpressure', async function () {
     if (process.env.SKIP_STREAM) return;
     const content = { content: true };
     const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
@@ -281,7 +285,7 @@ describe('Test Queue class', function() {
     stream.push(null);
     const result = await Queue.getReply(content, headers, rabbit.consumeChannel, this.name, queue);
     result.constructor.should.equal(Readable);
-    await new Promise(r => setTimeout(r, 100));
+    await new Promise((r) => setTimeout(r, 100));
     const chunks = [];
     for await (const chunk of result) {
       chunks.push(chunk);
@@ -293,7 +297,7 @@ describe('Test Queue class', function() {
       args1_15.push([rabbit.consumeChannel.replyName, { a: i }], [rabbit.consumeChannel.replyName, null]);
     }
     spy.args
-      .map(args => [args[0], JSON.parse(args[1].toString())])
+      .map((args) => [args[0], JSON.parse(args[1].toString())])
       .should.eql([
         [this.name, content],
         ...args1_15,
@@ -305,7 +309,7 @@ describe('Test Queue class', function() {
       ]);
   });
 
-  it('should getReply as a stream of Objects and handle error', async function() {
+  it('should getReply as a stream of Objects and handle error', async function () {
     if (process.env.SKIP_STREAM) return;
     if (process.env.SKIP_NODE_EARLIER_14) return;
     const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
@@ -337,7 +341,7 @@ describe('Test Queue class', function() {
     const streamHeaders = {
       correlationId: '1',
       contentType: 'application/json',
-      headers: { isStream: true, correlationId: '1' }
+      headers: { isStream: true, correlationId: '1', options: undefined }
     };
 
     spy.args.should.eql([
@@ -353,7 +357,7 @@ describe('Test Queue class', function() {
     ]);
   });
 
-  it('should getReply as a stream of Buffers and handle error', async function() {
+  it('should getReply as a stream of Buffers and handle error', async function () {
     if (process.env.SKIP_STREAM) return;
     if (process.env.SKIP_NODE_EARLIER_14) return;
     const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
@@ -385,7 +389,7 @@ describe('Test Queue class', function() {
     const streamHeaders = {
       correlationId: '1',
       contentType: 'application/json',
-      headers: { isStream: true, correlationId: '1' },
+      headers: { isStream: true, correlationId: '1', options: undefined },
       persistent: false,
       replyTo: queue.channel.replyName
     };
@@ -412,32 +416,36 @@ describe('Test Queue class', function() {
       [
         rabbit.consumeChannel.replyName,
         Buffer.from(JSON.stringify({ error: true, error_code: 999, error_message: 'test-error' })),
-        { correlationId: '1.1', contentType: 'application/json', headers: { isStream: true, correlationId: '1' } },
+        {
+          correlationId: '1.1',
+          contentType: 'application/json',
+          headers: { isStream: true, correlationId: '1', options: undefined }
+        },
         spy.args[5][3]
       ]
     ]);
   });
 
-  it('should bind to exchange', async function() {
+  it('should bind to exchange', async function () {
     const spy = sandbox.spy(rabbit.consumeChannel, 'bindQueue');
     const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await Queue.bindToExchange('amq.topic', this.name, rabbit.consumeChannel, this.name, queue);
     spy.calledWith(this.name, 'amq.topic', this.name);
   });
 
-  it('should unbind to exchange', async function() {
+  it('should unbind to exchange', async function () {
     const spy = sandbox.spy(rabbit.consumeChannel, 'unbindQueue');
     const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
     await Queue.unbindFromExchange('amq.topic', this.name, rabbit.consumeChannel, this.name, queue);
     spy.calledWith(this.name, 'amq.topic', this.name);
   });
 
-  it('should getReply as a stream and stop on demand', async function() {
+  it('should getReply as a stream and stop on demand', async function () {
     if (process.env.SKIP_STREAM) return;
     const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
     const content = { content: true };
     const headers = {
-      headers: { test: 1, backpressure: true },
+      headers: { test: 1, backpressure: true, options: {} },
       correlationId: '1',
       persistent: false,
       replyTo: rabbit.consumeChannel.replyName,
@@ -462,7 +470,7 @@ describe('Test Queue class', function() {
     const streamHeaders = {
       correlationId: '1',
       contentType: 'application/json',
-      headers: { isStream: true, correlationId: '1' },
+      headers: { isStream: true, correlationId: '1', options: {} },
       persistent: false,
       replyTo: queue.channel.replyName
     };
@@ -493,5 +501,60 @@ describe('Test Queue class', function() {
     ]);
     spy.args[0][3].should.be.Function();
     spy.args[3][3].should.be.Function();
+  });
+
+  it('should getReply as a stream and stop on demand with backpressure', async function () {
+    if (process.env.SKIP_STREAM) return;
+    const spy = sandbox.spy(rabbit.consumeChannel, 'sendToQueue');
+    const content = { content: true };
+    const headers = {
+      headers: { test: 1, backpressure: true, options: { highWaterMark: 1 } },
+      correlationId: '1',
+      persistent: false,
+      replyTo: rabbit.consumeChannel.replyName,
+      contentType: 'application/json'
+    };
+    const queue = new Queue(rabbit.consumeChannel, this.name, { exclusive: true });
+    const stream = new Readable({ objectMode: true, read() {} });
+    await queue.subscribe((msg, ack) => ack(null, stream));
+    stream.push('AB');
+    stream.push('BC');
+    stream.push('CD');
+    stream.push('DE');
+    const result: Readable = await Queue.getReply(content, headers, rabbit.consumeChannel, this.name, queue);
+    result.emit(Queue.STOP_STREAM);
+    stream.push(null);
+    result.constructor.should.equal(Readable);
+    const chunks = [];
+    for await (const chunk of result) {
+      chunks.push(chunk);
+    }
+    chunks.should.eql(['AB']);
+    const streamHeaders = {
+      correlationId: '1',
+      contentType: 'application/json',
+      headers: { isStream: true, correlationId: '1', options: { highWaterMark: 1 } },
+      persistent: false,
+      replyTo: queue.channel.replyName
+    };
+    const replyHeaders = {
+      contentType: 'application/json',
+      persistent: false
+    };
+    spy.args.should.eql([
+      [this.name, Buffer.from(JSON.stringify(content)), headers, spy.args[0][3]],
+      [
+        rabbit.consumeChannel.replyName,
+        Buffer.from(JSON.stringify('AB')),
+        { ...streamHeaders, correlationId: '1.0' },
+        spy.args[1][3]
+      ],
+      [
+        rabbit.consumeChannel.replyName,
+        Buffer.from(JSON.stringify(Queue.STOP_STREAM_MESSAGE)),
+        { ...replyHeaders, correlationId: '1.0' }
+      ]
+    ]);
+    spy.args[0][3].should.be.Function();
   });
 });

--- a/ts/queue.ts
+++ b/ts/queue.ts
@@ -99,7 +99,7 @@ export default class Queue {
         const properties = {
           correlationId,
           contentType: 'application/json',
-          headers: { isStream: true, correlationId }
+          headers: { isStream: true, correlationId, options: msg.properties?.headers?.options }
         };
         try {
           let id = 0;
@@ -118,6 +118,7 @@ export default class Queue {
               if (serviceResponse && serviceResponse.stopStream === Queue.STOP_STREAM_MESSAGE.stopStream) {
                 ack();
                 reply.destroy();
+                console.log('destroyed');
                 logger.info(`[${correlationId}] -> Received stopStream event. Closing connection`);
                 return;
               }


### PR DESCRIPTION
- When backpressure is on and consumer requests to stop, instead of waiting for consumer to request more data
we stop immediately.
- Ability to control from the consumer the stream that is created in consumer (eg HighWaterMark). This way consumer
can better control how many messages will request.