### PR TITLE
fix(handleError): define msg.properties.headers if it's undefined

### DIFF
--- a/ts/base-queue-handler.ts
+++ b/ts/base-queue-handler.ts
@@ -115,6 +115,9 @@ abstract class BaseQueueHandler {
 
   handleError(err, msg) {
     this.logger.error(err);
+    if (msg.properties.headers === undefined) {
+      msg.properties.headers = {};
+    }
     msg.properties.headers.errors = {
       name: err.name && err.name.substr(0, 200),
       message: err.message && err.message.substr(0, 200),


### PR DESCRIPTION
Hello,

First of all, thank you for your work,

I found a bug on BaseQueueHandler when a throw on my handle handleError throws an error because msg.properties.headers is undefined.

so here is a fix bug proposal.

Best regards

