### PR TITLE
fix: remove global npm upgrade from publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
-      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
       - run: |


### PR DESCRIPTION
## Summary
- The `npm install -g npm@latest` step in `npm-publish.yml` was failing with `MODULE_NOT_FOUND: promise-retry` during npm's self-upgrade on the GitHub Actions runner, blocking the v5.9.2 release ([failed run](https://github.com/Workable/rabbit-queue/actions/runs/25855201584)).
- Node 22 already ships with npm 10.x, which supports `--provenance` natively (requires >= 9.5.0), so the upgrade step is unnecessary.

## Test plan
- [ ] Merge, then re-run the v5.9.2 publish via `gh workflow run npm-publish.yml --ref v5.9.2` (or re-trigger from the release) and confirm it publishes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)