### PR TITLE
fix: bump publish workflow to Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
Node 22 ships with npm 10.x, which supports --provenance (OIDC attestation) but not OIDC-based publish authentication, so the registry rejected the PUT with a 404. Trusted Publishing needs npm >= 11.5.1; Node 24 (LTS) ships with npm 11.x natively.